### PR TITLE
Fix gamepad button mapping for dual-keycode controllers

### DIFF
--- a/app/src/main/java/com/replica/replicaisland/AndouKun.kt
+++ b/app/src/main/java/com/replica/replicaisland/AndouKun.kt
@@ -330,8 +330,15 @@ class AndouKun : Activity(), SensorEventListener {
 
     @SuppressLint("GestureBackNavigation")
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+        Log.d("claudeopus", "onKeyDown keyCode=$keyCode (${KeyEvent.keyCodeToString(keyCode)})")
         var result = true
-        if (keyCode == KeyEvent.KEYCODE_BACK) {
+        // Check if this is a gamepad BACK button (B button on many controllers)
+        val isGamepadSource = (event.source and InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD ||
+                              (event.source and InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK
+        if (keyCode == KeyEvent.KEYCODE_BACK && isGamepadSource) {
+            // Treat gamepad B button as attack, not back/exit
+            result = mGame!!.onKeyDownEvent(keyCode)
+        } else if (keyCode == KeyEvent.KEYCODE_BACK) {
             val time = System.currentTimeMillis()
             if (time - lastRollTime > ROLL_TO_FACE_BUTTON_DELAY &&
                     time - lastTouchTime > ROLL_TO_FACE_BUTTON_DELAY) {
@@ -369,7 +376,13 @@ class AndouKun : Activity(), SensorEventListener {
     @SuppressLint("GestureBackNavigation")
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
         var result = false
-        if (keyCode == KeyEvent.KEYCODE_BACK) {
+        // Check if this is a gamepad BACK button (B button on many controllers)
+        val isGamepadSource = (event.source and InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD ||
+                              (event.source and InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK
+        if (keyCode == KeyEvent.KEYCODE_BACK && isGamepadSource) {
+            // Treat gamepad B button as attack, not back/exit
+            result = mGame!!.onKeyUpEvent(keyCode)
+        } else if (keyCode == KeyEvent.KEYCODE_BACK) {
             result = true
         } else if (keyCode == KeyEvent.KEYCODE_MENU) {
             if (VERSION < 0) {

--- a/app/src/main/java/com/replica/replicaisland/input/InputGameInterface.kt
+++ b/app/src/main/java/com/replica/replicaisland/input/InputGameInterface.kt
@@ -215,13 +215,20 @@ class InputGameInterface : BaseObject() {
                 ButtonConstants.STOMP_BUTTON_REGION_Y.toFloat(),
                 ButtonConstants.STOMP_BUTTON_REGION_WIDTH.toFloat(),
                 ButtonConstants.STOMP_BUTTON_REGION_HEIGHT.toFloat())
-        val gamepadAttack = keys[KeyEvent.KEYCODE_BUTTON_B]
-        if (useClickButtonForAttack && clickButton!!.pressed) {
+        val gamepadAttackB = keys[KeyEvent.KEYCODE_BUTTON_B]
+        val gamepadAttackBack = keys[KeyEvent.KEYCODE_BACK] // B button also sends BACK on some controllers
+        // Check if gamepad A button is pressed (sends DPAD_CENTER on some controllers)
+        // If so, don't use clickButton for attack to avoid A triggering both jump and attack
+        val gamepadAPressed = gamepadJump?.pressed == true
+        val useClickForAttack = useClickButtonForAttack && !gamepadAPressed
+        if (useClickForAttack && clickButton!!.pressed) {
             attackButton.press(clickButton.lastPressedTime, clickButton.magnitude)
         } else if (attackKey!!.pressed) {
             attackButton.press(attackKey.lastPressedTime, attackKey.magnitude)
-        } else if (gamepadAttack?.pressed == true) {
-            attackButton.press(gamepadAttack.lastPressedTime, gamepadAttack.magnitude)
+        } else if (gamepadAttackB?.pressed == true) {
+            attackButton.press(gamepadAttackB.lastPressedTime, gamepadAttackB.magnitude)
+        } else if (gamepadAttackBack?.pressed == true) {
+            attackButton.press(gamepadAttackBack.lastPressedTime, gamepadAttackBack.magnitude)
         } else if (stompTouch != null) {
             // Since touch events come in constantly, we only want to press the attack button
             // here if it's not already down.  That makes it act like the other buttons (down once then up).


### PR DESCRIPTION
## Summary
- Fix button mapping for controllers that send dual keycodes per button
- Handle A button sending BUTTON_A + DPAD_CENTER (prevent double-action)
- Handle B button sending BUTTON_B + BACK (intercept to avoid exit dialog)
- Add KEYCODE_BACK as attack input for possession orb long-press support
- Add keycode debug logging with "claudeopus" tag
- Reduce gamepad joystick sensitivity (GAMEPAD_FILTER = 0.18)
- Only log gamepad state on state changes (not every frame)

## Button Mapping (after fix)
- **A button**: Jump only (DPAD_CENTER no longer triggers attack when A pressed)
- **B button**: Attack with long-press for possession orb (BACK intercepted from gamepad)

## Controller Keycodes Detected
```
A: KEYCODE_BUTTON_A (96) + KEYCODE_DPAD_CENTER (23)
B: KEYCODE_BUTTON_B (97) + KEYCODE_BACK (4)
X: KEYCODE_BUTTON_X (99) + KEYCODE_DEL (67)
Y: KEYCODE_BUTTON_Y (100) + KEYCODE_SPACE (62)
```

## Test plan
- [ ] A button triggers jump only (not attack)
- [ ] B button triggers attack (not exit dialog)
- [ ] Long-press B on ground spawns possession orb/ghost
- [ ] Joystick movement feels appropriately scaled

🤖 Generated with [Claude Code](https://claude.ai/code)