### PR TITLE
Add gamepad controller work-in-progress note to README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -87,6 +87,10 @@ as of Sept 2025:
 
 https://code.google.com/archive/p/replicaisland/
 
+**Gamepad Controller Support** (in progress on `claudeopus45` branch): Adding support for
+game controllers with joystick movement and button mapping (A=jump, B=attack with long-press
+for possession orb).
+
 ## USAGE NOTES
 
 On Android emulators at API23 (Marshmallow) the on screen controls appear to


### PR DESCRIPTION
## Summary
Add a note to the ADDENDUM section of README.md indicating that gamepad controller support is being developed on the `claudeopus45` branch.

## Changes
- Added note about gamepad controller support (joystick movement, A=jump, B=attack with long-press for possession orb)

🤖 Generated with [Claude Code](https://claude.ai/code)