### PR TITLE
Update CHANGELOG and README for DialogFragment migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
 ReplicaIslandKotlin Change Log
 ===============================
-Version K.0.2 *(2025-10-28)
+
+Version K.0.4 *(2026-01-22)*
 ---------------------------------
-* conver to KTS build files, update versions
+* Convert dialog Activities to modern DialogFragment architecture
+  - DiaryDialogFragment: Replaces DiaryActivity for diary entry display
+  - ConversationDialogFragment: Replaces ConversationDialogActivity with typewriter text effect
+  - LevelSelectDialogFragment: Replaces LevelSelectActivity using Fragment Result API
+* Extract TypewriterTextView as standalone reusable component
+* Convert AndouKun from Activity to AppCompatActivity for fragment support
+* Add test infrastructure with Espresso and fragment-testing dependencies
+* Add instrumented tests for all three DialogFragments (10 test cases)
+* Deprecate original dialog activities (kept for rollback option)
+
+Version K.0.3 *(2025-12)*
+---------------------------------
+* Migrate preferences from PreferenceActivity to PreferenceFragmentCompat
+* Add DataStore infrastructure with dual-write migration strategy
+* Connect Settings UI directly to DataStore
+* Migrate activities to use PreferencesManager facade
+
+Version K.0.2 *(2025-10-28)*
+---------------------------------
+* Convert to KTS build files, update versions
 
 Version K.0.1 *(2021-05-17)
 ---------------------------------

--- a/README.MD
+++ b/README.MD
@@ -15,10 +15,15 @@ and other data are included along with the code.
 
 ### ABOUT THE SOURCE
 
-The code is structured into several Activities for the main menu, level select screen, dialog window, and main game.
-Most of the code in this project is related to src/com/replicaisland/AndouKun.java,
-which implements the core game Activity ("AndouKun" was the code name for this project
-and you can find references to it all over the code).
+The code is structured into several Activities and DialogFragments for the main menu, level select, dialogs, and main game.
+The core game logic is in `src/com/replica/replicaisland/AndouKun.kt`, which implements the main game Activity
+(now extends AppCompatActivity for fragment support). "AndouKun" was the code name for this project
+and you can find references to it all over the code.
+
+**Modern Dialog Architecture**: The game uses DialogFragments for in-game dialogs:
+- `DiaryDialogFragment` - Displays collected diary entries with animated background
+- `ConversationDialogFragment` - Shows NPC conversations with typewriter text effect
+- `LevelSelectDialogFragment` - Level selection using Fragment Result API for communication
 
 The game loop itself is structured as follows:
 
@@ -87,9 +92,14 @@ as of Sept 2025:
 
 https://code.google.com/archive/p/replicaisland/
 
-**Gamepad Controller Support** (in progress on `claudeopus45` branch): Adding support for
-game controllers with joystick movement and button mapping (A=jump, B=attack with long-press
-for possession orb).
+**Gamepad Controller Support** (in progress): Adding support for game controllers with
+joystick movement and button mapping (A=jump, B=attack with long-press for possession orb).
+
+**Modern Android Architecture**: Recent updates include:
+- DialogFragment-based dialogs replacing legacy Activity dialogs
+- PreferenceFragmentCompat for settings screen
+- DataStore for preferences (migrated from SharedPreferences)
+- Instrumented tests with Espresso and fragment-testing
 
 ## USAGE NOTES
 
@@ -102,8 +112,12 @@ You can fix this by checking the box `On-Screen Controls` in the `Configure` men
 
 ![Config box](docs/img/README-usage-02.PNG)
 
-## updating further in 2025... Stay tuned.
+## Development Status
+
+Actively maintained and updated for modern Android development practices.
 
 Currently set up for:
 
-<b>Android Studio Narwhal 4 Feature Drop | 2025.1.4</b>
+**Android Studio Narwhal 4 Feature Drop | 2025.1.4**
+
+Target SDK: 36 | Min SDK: 24


### PR DESCRIPTION
## Summary
- Add changelog entries for recent modernization work
- Update README to document new architecture patterns

## Changes

### CHANGELOG.md
- **Version K.0.4** (2026-01-22): DialogFragment conversion with instrumented tests
- **Version K.0.3** (2025-12): DataStore/Preferences migration

### README.md
- Updated "ABOUT THE SOURCE" to describe DialogFragment architecture
- Added "Modern Android Architecture" section
- Updated development status with SDK information

## Test plan
- [x] Documentation review - no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)