### PR TITLE
Convert menu dialogs to DialogFragments

### DIFF
--- a/app/src/androidTest/java/com/replica/replicaisland/ui/ControlSetupDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/replica/replicaisland/ui/ControlSetupDialogFragmentTest.kt
@@ -19,6 +19,7 @@ import androidx.fragment.app.testing.launchFragment
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -36,22 +37,27 @@ class ControlSetupDialogFragmentTest {
     @Test
     fun dialogDisplaysCorrectTitle() {
         launchFragment<ControlSetupDialogFragment>(
-            fragmentArgs = ControlSetupDialogFragment.newInstance("Test Controls").arguments
+            fragmentArgs = ControlSetupDialogFragment.newInstance("Test Controls").arguments,
+            themeResId = R.style.Theme_FullscreenDialogFragment
         )
 
         onView(withText(R.string.control_setup_dialog_title))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 
     @Test
     fun dialogDisplaysOkAndChangeButtons() {
         launchFragment<ControlSetupDialogFragment>(
-            fragmentArgs = ControlSetupDialogFragment.newInstance("Test Controls").arguments
+            fragmentArgs = ControlSetupDialogFragment.newInstance("Test Controls").arguments,
+            themeResId = R.style.Theme_FullscreenDialogFragment
         )
 
         onView(withText(R.string.control_setup_dialog_ok))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
         onView(withText(R.string.control_setup_dialog_change))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 
@@ -59,7 +65,8 @@ class ControlSetupDialogFragmentTest {
     fun changeButtonSendsFragmentResult() {
         var resultReceived = false
         val scenario = launchFragment<ControlSetupDialogFragment>(
-            fragmentArgs = ControlSetupDialogFragment.newInstance("Test Controls").arguments
+            fragmentArgs = ControlSetupDialogFragment.newInstance("Test Controls").arguments,
+            themeResId = R.style.Theme_FullscreenDialogFragment
         )
 
         scenario.onFragment { fragment ->
@@ -71,7 +78,9 @@ class ControlSetupDialogFragmentTest {
             }
         }
 
-        onView(withText(R.string.control_setup_dialog_change)).perform(click())
+        onView(withText(R.string.control_setup_dialog_change))
+            .inRoot(isDialog())
+            .perform(click())
 
         // Give time for result to be delivered
         Thread.sleep(100)

--- a/app/src/androidTest/java/com/replica/replicaisland/ui/ControlSetupDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/replica/replicaisland/ui/ControlSetupDialogFragmentTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025 Jim Andreas
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.replica.replicaisland.ui
+
+import androidx.fragment.app.testing.launchFragment
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.replica.replicaisland.R
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented tests for ControlSetupDialogFragment.
+ */
+@RunWith(AndroidJUnit4::class)
+class ControlSetupDialogFragmentTest {
+
+    @Test
+    fun dialogDisplaysCorrectTitle() {
+        launchFragment<ControlSetupDialogFragment>(
+            fragmentArgs = ControlSetupDialogFragment.newInstance("Test Controls").arguments
+        )
+
+        onView(withText(R.string.control_setup_dialog_title))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun dialogDisplaysOkAndChangeButtons() {
+        launchFragment<ControlSetupDialogFragment>(
+            fragmentArgs = ControlSetupDialogFragment.newInstance("Test Controls").arguments
+        )
+
+        onView(withText(R.string.control_setup_dialog_ok))
+            .check(matches(isDisplayed()))
+        onView(withText(R.string.control_setup_dialog_change))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun changeButtonSendsFragmentResult() {
+        var resultReceived = false
+        val scenario = launchFragment<ControlSetupDialogFragment>(
+            fragmentArgs = ControlSetupDialogFragment.newInstance("Test Controls").arguments
+        )
+
+        scenario.onFragment { fragment ->
+            fragment.parentFragmentManager.setFragmentResultListener(
+                ControlSetupDialogFragment.REQUEST_KEY,
+                fragment
+            ) { _, bundle ->
+                resultReceived = bundle.getBoolean(ControlSetupDialogFragment.RESULT_OPEN_SETTINGS)
+            }
+        }
+
+        onView(withText(R.string.control_setup_dialog_change)).perform(click())
+
+        // Give time for result to be delivered
+        Thread.sleep(100)
+        assertTrue("Fragment result should be received with open_settings=true", resultReceived)
+    }
+}

--- a/app/src/androidTest/java/com/replica/replicaisland/ui/ExtrasLockedDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/replica/replicaisland/ui/ExtrasLockedDialogFragmentTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Jim Andreas
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.replica.replicaisland.ui
+
+import androidx.fragment.app.testing.launchFragment
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.replica.replicaisland.R
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented tests for ExtrasLockedDialogFragment.
+ */
+@RunWith(AndroidJUnit4::class)
+class ExtrasLockedDialogFragmentTest {
+
+    @Test
+    fun dialogDisplaysCorrectTitle() {
+        launchFragment<ExtrasLockedDialogFragment>()
+
+        onView(withText(R.string.extras_locked_dialog_title))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun dialogDisplaysCorrectMessage() {
+        launchFragment<ExtrasLockedDialogFragment>()
+
+        onView(withText(R.string.extras_locked_dialog_message))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun dialogDisplaysOkButton() {
+        launchFragment<ExtrasLockedDialogFragment>()
+
+        onView(withText(R.string.extras_locked_dialog_ok))
+            .check(matches(isDisplayed()))
+    }
+}

--- a/app/src/androidTest/java/com/replica/replicaisland/ui/ExtrasLockedDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/replica/replicaisland/ui/ExtrasLockedDialogFragmentTest.kt
@@ -18,6 +18,7 @@ package com.replica.replicaisland.ui
 import androidx.fragment.app.testing.launchFragment
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -33,25 +34,34 @@ class ExtrasLockedDialogFragmentTest {
 
     @Test
     fun dialogDisplaysCorrectTitle() {
-        launchFragment<ExtrasLockedDialogFragment>()
+        launchFragment<ExtrasLockedDialogFragment>(
+            themeResId = R.style.Theme_FullscreenDialogFragment
+        )
 
         onView(withText(R.string.extras_locked_dialog_title))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 
     @Test
     fun dialogDisplaysCorrectMessage() {
-        launchFragment<ExtrasLockedDialogFragment>()
+        launchFragment<ExtrasLockedDialogFragment>(
+            themeResId = R.style.Theme_FullscreenDialogFragment
+        )
 
         onView(withText(R.string.extras_locked_dialog_message))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 
     @Test
     fun dialogDisplaysOkButton() {
-        launchFragment<ExtrasLockedDialogFragment>()
+        launchFragment<ExtrasLockedDialogFragment>(
+            themeResId = R.style.Theme_FullscreenDialogFragment
+        )
 
         onView(withText(R.string.extras_locked_dialog_ok))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 }

--- a/app/src/androidTest/java/com/replica/replicaisland/ui/NewGameDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/replica/replicaisland/ui/NewGameDialogFragmentTest.kt
@@ -19,6 +19,7 @@ import androidx.fragment.app.testing.launchFragment
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -37,32 +38,39 @@ class NewGameDialogFragmentTest {
     @Test
     fun dialogDisplaysCorrectTitle() {
         launchFragment<NewGameDialogFragment>(
-            fragmentArgs = NewGameDialogFragment.newInstance(0).arguments
+            fragmentArgs = NewGameDialogFragment.newInstance(0).arguments,
+            themeResId = R.style.Theme_FullscreenDialogFragment
         )
 
         onView(withText(R.string.new_game_dialog_title))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 
     @Test
     fun dialogDisplaysCorrectMessage() {
         launchFragment<NewGameDialogFragment>(
-            fragmentArgs = NewGameDialogFragment.newInstance(0).arguments
+            fragmentArgs = NewGameDialogFragment.newInstance(0).arguments,
+            themeResId = R.style.Theme_FullscreenDialogFragment
         )
 
         onView(withText(R.string.new_game_dialog_message))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 
     @Test
     fun dialogDisplaysOkAndCancelButtons() {
         launchFragment<NewGameDialogFragment>(
-            fragmentArgs = NewGameDialogFragment.newInstance(0).arguments
+            fragmentArgs = NewGameDialogFragment.newInstance(0).arguments,
+            themeResId = R.style.Theme_FullscreenDialogFragment
         )
 
         onView(withText(R.string.new_game_dialog_ok))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
         onView(withText(R.string.new_game_dialog_cancel))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 
@@ -73,7 +81,8 @@ class NewGameDialogFragmentTest {
         val expectedGameType = 1
 
         val scenario = launchFragment<NewGameDialogFragment>(
-            fragmentArgs = NewGameDialogFragment.newInstance(expectedGameType).arguments
+            fragmentArgs = NewGameDialogFragment.newInstance(expectedGameType).arguments,
+            themeResId = R.style.Theme_FullscreenDialogFragment
         )
 
         scenario.onFragment { fragment ->
@@ -86,7 +95,9 @@ class NewGameDialogFragmentTest {
             }
         }
 
-        onView(withText(R.string.new_game_dialog_ok)).perform(click())
+        onView(withText(R.string.new_game_dialog_ok))
+            .inRoot(isDialog())
+            .perform(click())
 
         // Give time for result to be delivered
         Thread.sleep(100)

--- a/app/src/androidTest/java/com/replica/replicaisland/ui/NewGameDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/replica/replicaisland/ui/NewGameDialogFragmentTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2025 Jim Andreas
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.replica.replicaisland.ui
+
+import androidx.fragment.app.testing.launchFragment
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.replica.replicaisland.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented tests for NewGameDialogFragment.
+ */
+@RunWith(AndroidJUnit4::class)
+class NewGameDialogFragmentTest {
+
+    @Test
+    fun dialogDisplaysCorrectTitle() {
+        launchFragment<NewGameDialogFragment>(
+            fragmentArgs = NewGameDialogFragment.newInstance(0).arguments
+        )
+
+        onView(withText(R.string.new_game_dialog_title))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun dialogDisplaysCorrectMessage() {
+        launchFragment<NewGameDialogFragment>(
+            fragmentArgs = NewGameDialogFragment.newInstance(0).arguments
+        )
+
+        onView(withText(R.string.new_game_dialog_message))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun dialogDisplaysOkAndCancelButtons() {
+        launchFragment<NewGameDialogFragment>(
+            fragmentArgs = NewGameDialogFragment.newInstance(0).arguments
+        )
+
+        onView(withText(R.string.new_game_dialog_ok))
+            .check(matches(isDisplayed()))
+        onView(withText(R.string.new_game_dialog_cancel))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun positiveButtonSendsFragmentResultWithGameType() {
+        var confirmed = false
+        var gameStartType = -1
+        val expectedGameType = 1
+
+        val scenario = launchFragment<NewGameDialogFragment>(
+            fragmentArgs = NewGameDialogFragment.newInstance(expectedGameType).arguments
+        )
+
+        scenario.onFragment { fragment ->
+            fragment.parentFragmentManager.setFragmentResultListener(
+                NewGameDialogFragment.REQUEST_KEY,
+                fragment
+            ) { _, bundle ->
+                confirmed = bundle.getBoolean(NewGameDialogFragment.RESULT_CONFIRMED)
+                gameStartType = bundle.getInt(NewGameDialogFragment.RESULT_GAME_START_TYPE)
+            }
+        }
+
+        onView(withText(R.string.new_game_dialog_ok)).perform(click())
+
+        // Give time for result to be delivered
+        Thread.sleep(100)
+        assertTrue("Fragment result should have confirmed=true", confirmed)
+        assertEquals("Game start type should match", expectedGameType, gameStartType)
+    }
+}

--- a/app/src/androidTest/java/com/replica/replicaisland/ui/TiltControlsDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/replica/replicaisland/ui/TiltControlsDialogFragmentTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025 Jim Andreas
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.replica.replicaisland.ui
+
+import androidx.fragment.app.testing.launchFragment
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.replica.replicaisland.R
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented tests for TiltControlsDialogFragment.
+ */
+@RunWith(AndroidJUnit4::class)
+class TiltControlsDialogFragmentTest {
+
+    @Test
+    fun dialogDisplaysCorrectTitle() {
+        launchFragment<TiltControlsDialogFragment>()
+
+        onView(withText(R.string.onscreen_tilt_dialog_title))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun dialogDisplaysCorrectMessage() {
+        launchFragment<TiltControlsDialogFragment>()
+
+        onView(withText(R.string.onscreen_tilt_dialog_message))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun dialogDisplaysOkAndCancelButtons() {
+        launchFragment<TiltControlsDialogFragment>()
+
+        onView(withText(R.string.onscreen_tilt_dialog_ok))
+            .check(matches(isDisplayed()))
+        onView(withText(R.string.onscreen_tilt_dialog_cancel))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun positiveButtonSendsFragmentResult() {
+        var resultReceived = false
+        val scenario = launchFragment<TiltControlsDialogFragment>()
+
+        scenario.onFragment { fragment ->
+            fragment.parentFragmentManager.setFragmentResultListener(
+                TiltControlsDialogFragment.REQUEST_KEY,
+                fragment
+            ) { _, bundle ->
+                resultReceived = bundle.getBoolean(TiltControlsDialogFragment.RESULT_ENABLE_SCREEN_CONTROLS)
+            }
+        }
+
+        onView(withText(R.string.onscreen_tilt_dialog_ok)).perform(click())
+
+        // Give time for result to be delivered
+        Thread.sleep(100)
+        assertTrue("Fragment result should be received with enable_screen_controls=true", resultReceived)
+    }
+}

--- a/app/src/androidTest/java/com/replica/replicaisland/ui/TiltControlsDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/replica/replicaisland/ui/TiltControlsDialogFragmentTest.kt
@@ -19,6 +19,7 @@ import androidx.fragment.app.testing.launchFragment
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -35,34 +36,46 @@ class TiltControlsDialogFragmentTest {
 
     @Test
     fun dialogDisplaysCorrectTitle() {
-        launchFragment<TiltControlsDialogFragment>()
+        launchFragment<TiltControlsDialogFragment>(
+            themeResId = R.style.Theme_FullscreenDialogFragment
+        )
 
         onView(withText(R.string.onscreen_tilt_dialog_title))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 
     @Test
     fun dialogDisplaysCorrectMessage() {
-        launchFragment<TiltControlsDialogFragment>()
+        launchFragment<TiltControlsDialogFragment>(
+            themeResId = R.style.Theme_FullscreenDialogFragment
+        )
 
         onView(withText(R.string.onscreen_tilt_dialog_message))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 
     @Test
     fun dialogDisplaysOkAndCancelButtons() {
-        launchFragment<TiltControlsDialogFragment>()
+        launchFragment<TiltControlsDialogFragment>(
+            themeResId = R.style.Theme_FullscreenDialogFragment
+        )
 
         onView(withText(R.string.onscreen_tilt_dialog_ok))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
         onView(withText(R.string.onscreen_tilt_dialog_cancel))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 
     @Test
     fun positiveButtonSendsFragmentResult() {
         var resultReceived = false
-        val scenario = launchFragment<TiltControlsDialogFragment>()
+        val scenario = launchFragment<TiltControlsDialogFragment>(
+            themeResId = R.style.Theme_FullscreenDialogFragment
+        )
 
         scenario.onFragment { fragment ->
             fragment.parentFragmentManager.setFragmentResultListener(
@@ -73,7 +86,9 @@ class TiltControlsDialogFragmentTest {
             }
         }
 
-        onView(withText(R.string.onscreen_tilt_dialog_ok)).perform(click())
+        onView(withText(R.string.onscreen_tilt_dialog_ok))
+            .inRoot(isDialog())
+            .perform(click())
 
         // Give time for result to be delivered
         Thread.sleep(100)

--- a/app/src/androidTest/java/com/replica/replicaisland/ui/WhatsNewDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/replica/replicaisland/ui/WhatsNewDialogFragmentTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Jim Andreas
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.replica.replicaisland.ui
+
+import androidx.fragment.app.testing.launchFragment
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.replica.replicaisland.R
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented tests for WhatsNewDialogFragment.
+ */
+@RunWith(AndroidJUnit4::class)
+class WhatsNewDialogFragmentTest {
+
+    @Test
+    fun dialogDisplaysCorrectTitle() {
+        launchFragment<WhatsNewDialogFragment>()
+
+        onView(withText(R.string.whats_new_dialog_title))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun dialogDisplaysCorrectMessage() {
+        launchFragment<WhatsNewDialogFragment>()
+
+        onView(withText(R.string.whats_new_dialog_message))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun dialogDisplaysOkButton() {
+        launchFragment<WhatsNewDialogFragment>()
+
+        onView(withText(R.string.whats_new_dialog_ok))
+            .check(matches(isDisplayed()))
+    }
+}

--- a/app/src/androidTest/java/com/replica/replicaisland/ui/WhatsNewDialogFragmentTest.kt
+++ b/app/src/androidTest/java/com/replica/replicaisland/ui/WhatsNewDialogFragmentTest.kt
@@ -18,6 +18,7 @@ package com.replica.replicaisland.ui
 import androidx.fragment.app.testing.launchFragment
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -33,25 +34,34 @@ class WhatsNewDialogFragmentTest {
 
     @Test
     fun dialogDisplaysCorrectTitle() {
-        launchFragment<WhatsNewDialogFragment>()
+        launchFragment<WhatsNewDialogFragment>(
+            themeResId = R.style.Theme_FullscreenDialogFragment
+        )
 
         onView(withText(R.string.whats_new_dialog_title))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 
     @Test
     fun dialogDisplaysCorrectMessage() {
-        launchFragment<WhatsNewDialogFragment>()
+        launchFragment<WhatsNewDialogFragment>(
+            themeResId = R.style.Theme_FullscreenDialogFragment
+        )
 
         onView(withText(R.string.whats_new_dialog_message))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 
     @Test
     fun dialogDisplaysOkButton() {
-        launchFragment<WhatsNewDialogFragment>()
+        launchFragment<WhatsNewDialogFragment>(
+            themeResId = R.style.Theme_FullscreenDialogFragment
+        )
 
         onView(withText(R.string.whats_new_dialog_ok))
+            .inRoot(isDialog())
             .check(matches(isDisplayed()))
     }
 }

--- a/app/src/main/java/com/replica/replicaisland/ui/ControlSetupDialogFragment.kt
+++ b/app/src/main/java/com/replica/replicaisland/ui/ControlSetupDialogFragment.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Jim Andreas
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.replica.replicaisland.ui
+
+import android.app.Dialog
+import android.os.Bundle
+import android.text.Html
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.replica.replicaisland.R
+
+/**
+ * DialogFragment that displays the auto-selected control scheme to new users
+ * and offers the option to change it. Uses Fragment Result API to communicate
+ * the user's choice back to the activity.
+ */
+class ControlSetupDialogFragment : DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val controlsString = requireArguments().getString(ARG_CONTROLS_STRING, "")
+        val messageFormat = resources.getString(R.string.control_setup_dialog_message)
+        val message = String.format(messageFormat, controlsString)
+        val styledMessage = Html.fromHtml(message, Html.FROM_HTML_MODE_LEGACY)
+
+        return AlertDialog.Builder(requireContext())
+            .setTitle(R.string.control_setup_dialog_title)
+            .setMessage(styledMessage)
+            .setPositiveButton(R.string.control_setup_dialog_ok, null)
+            .setNegativeButton(R.string.control_setup_dialog_change) { _, _ ->
+                setFragmentResult(REQUEST_KEY, bundleOf(RESULT_OPEN_SETTINGS to true))
+            }
+            .create()
+    }
+
+    companion object {
+        const val TAG = "ControlSetupDialogFragment"
+        const val REQUEST_KEY = "control_setup_request"
+        const val RESULT_OPEN_SETTINGS = "open_settings"
+        private const val ARG_CONTROLS_STRING = "controls_string"
+
+        fun newInstance(selectedControlsString: String) = ControlSetupDialogFragment().apply {
+            arguments = bundleOf(ARG_CONTROLS_STRING to selectedControlsString)
+        }
+    }
+}

--- a/app/src/main/java/com/replica/replicaisland/ui/ExtrasLockedDialogFragment.kt
+++ b/app/src/main/java/com/replica/replicaisland/ui/ExtrasLockedDialogFragment.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Jim Andreas
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.replica.replicaisland.ui
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import com.replica.replicaisland.R
+
+/**
+ * DialogFragment that informs the user that extras are locked until they
+ * complete certain game achievements.
+ */
+class ExtrasLockedDialogFragment : DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return AlertDialog.Builder(requireContext())
+            .setTitle(R.string.extras_locked_dialog_title)
+            .setMessage(R.string.extras_locked_dialog_message)
+            .setPositiveButton(R.string.extras_locked_dialog_ok, null)
+            .create()
+    }
+
+    companion object {
+        const val TAG = "ExtrasLockedDialogFragment"
+
+        fun newInstance() = ExtrasLockedDialogFragment()
+    }
+}

--- a/app/src/main/java/com/replica/replicaisland/ui/ExtrasMenuActivity.kt
+++ b/app/src/main/java/com/replica/replicaisland/ui/ExtrasMenuActivity.kt
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION", "unused")
+@file:Suppress("unused")
 
 package com.replica.replicaisland.ui
 
 import android.annotation.SuppressLint
-import android.app.Activity
-import android.app.AlertDialog
-import android.app.Dialog
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.media.AudioManager
@@ -30,6 +27,7 @@ import android.view.KeyEvent
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -37,7 +35,7 @@ import com.replica.replicaisland.R
 import com.replica.replicaisland.data.PreferencesManager
 import java.lang.reflect.InvocationTargetException
 
-class ExtrasMenuActivity : Activity() {
+class ExtrasMenuActivity : AppCompatActivity() {
     private var mLinearModeButton: View? = null
     private var mLevelSelectButton: View? = null
     private var mControlsButton: View? = null
@@ -48,14 +46,13 @@ class ExtrasMenuActivity : Activity() {
     private var fadeOutAnimation: Animation? = null
     private var alternateFadeOutAnimation: Animation? = null
     private var lockedAnimation: Animation? = null
-    private var pendingGameStart = 0
     private val sLinearModeButtonListener = View.OnClickListener {
         val prefsManager = PreferencesManager.getInstance(this)
         val row = prefsManager.getLevelRow()
         val index = prefsManager.getLevelIndex()
         if (row != 0 || index != 0) {
-            pendingGameStart = START_LINEAR_MODE
-            showDialog(NEW_GAME_DIALOG)
+            NewGameDialogFragment.newInstance(START_LINEAR_MODE)
+                .show(supportFragmentManager, NewGameDialogFragment.TAG)
         } else {
             startGame(START_LINEAR_MODE)
         }
@@ -65,13 +62,16 @@ class ExtrasMenuActivity : Activity() {
         val row = prefsManager.getLevelRow()
         val index = prefsManager.getLevelIndex()
         if (row != 0 || index != 0) {
-            pendingGameStart = START_LEVEL_SELECT
-            showDialog(NEW_GAME_DIALOG)
+            NewGameDialogFragment.newInstance(START_LEVEL_SELECT)
+                .show(supportFragmentManager, NewGameDialogFragment.TAG)
         } else {
             startGame(START_LEVEL_SELECT)
         }
     }
-    private val sLockedSelectButtonListener = View.OnClickListener { showDialog(EXTRAS_LOCKED_DIALOG) }
+    private val sLockedSelectButtonListener = View.OnClickListener {
+        ExtrasLockedDialogFragment.newInstance()
+            .show(supportFragmentManager, ExtrasLockedDialogFragment.TAG)
+    }
     private val sControlsButtonListener = View.OnClickListener { v ->
         val i = Intent(baseContext, SetPreferencesActivity::class.java)
         i.putExtra("controlConfig", true)
@@ -125,6 +125,16 @@ class ExtrasMenuActivity : Activity() {
 
         // Keep the volume control type consistent across all activities.
         volumeControlStream = AudioManager.STREAM_MUSIC
+
+        // Set up fragment result listener for new game dialog callback
+        supportFragmentManager.setFragmentResultListener(
+            NewGameDialogFragment.REQUEST_KEY, this
+        ) { _, bundle ->
+            if (bundle.getBoolean(NewGameDialogFragment.RESULT_CONFIRMED)) {
+                val gameStartType = bundle.getInt(NewGameDialogFragment.RESULT_GAME_START_TYPE)
+                startGame(gameStartType)
+            }
+        }
     }
 
     @SuppressLint("GestureBackNavigation")
@@ -145,25 +155,6 @@ class ExtrasMenuActivity : Activity() {
             result = super.onKeyDown(keyCode, event)
         }
         return result
-    }
-
-    override fun onCreateDialog(id: Int): Dialog {
-        var dialog: Dialog? = null
-        if (id == NEW_GAME_DIALOG) {
-            dialog = AlertDialog.Builder(this)
-                    .setTitle(R.string.new_game_dialog_title)
-                    .setPositiveButton(R.string.new_game_dialog_ok) { _, whichButton -> startGame(pendingGameStart) }
-                    .setNegativeButton(R.string.new_game_dialog_cancel, null)
-                    .setMessage(R.string.new_game_dialog_message)
-                    .create()
-        } else if (id == EXTRAS_LOCKED_DIALOG) {
-            dialog = AlertDialog.Builder(this)
-                    .setTitle(R.string.extras_locked_dialog_title)
-                    .setPositiveButton(R.string.extras_locked_dialog_ok, null)
-                    .setMessage(R.string.extras_locked_dialog_message)
-                    .create()
-        }
-        return dialog!!
     }
 
     private fun startGame(type: Int) {
@@ -214,8 +205,6 @@ class ExtrasMenuActivity : Activity() {
     }
 
     companion object {
-        const val NEW_GAME_DIALOG = 0
-        const val EXTRAS_LOCKED_DIALOG = 1
         private const val START_LINEAR_MODE = 0
         private const val START_LEVEL_SELECT = 1
     }

--- a/app/src/main/java/com/replica/replicaisland/ui/MainMenuActivity.kt
+++ b/app/src/main/java/com/replica/replicaisland/ui/MainMenuActivity.kt
@@ -14,24 +14,21 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION", "unused", "CascadeIf")
+@file:Suppress("unused", "CascadeIf")
 
 package com.replica.replicaisland.ui
 
 import android.annotation.SuppressLint
-import android.app.Activity
-import android.app.AlertDialog
-import android.app.Dialog
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.media.AudioManager
 import android.os.Build
 import android.os.Bundle
-import android.text.Html
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.widget.ImageView
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -45,7 +42,7 @@ import com.replica.replicaisland.levels.LevelTree
 import java.lang.reflect.InvocationTargetException
 import kotlin.math.abs
 
-class MainMenuActivity : Activity() {
+class MainMenuActivity : AppCompatActivity() {
     private var paused = false
     private var mStartButton: View? = null
     private var optionsButton: View? = null
@@ -155,6 +152,25 @@ class MainMenuActivity : Activity() {
         // Keep the volume control type consistent across all activities.
         volumeControlStream = AudioManager.STREAM_MUSIC
 
+        // Set up fragment result listeners for dialog callbacks
+        supportFragmentManager.setFragmentResultListener(
+            TiltControlsDialogFragment.REQUEST_KEY, this
+        ) { _, bundle ->
+            if (bundle.getBoolean(TiltControlsDialogFragment.RESULT_ENABLE_SCREEN_CONTROLS)) {
+                PreferencesManager.getInstance(this).setScreenControls(true)
+            }
+        }
+
+        supportFragmentManager.setFragmentResultListener(
+            ControlSetupDialogFragment.REQUEST_KEY, this
+        ) { _, bundle ->
+            if (bundle.getBoolean(ControlSetupDialogFragment.RESULT_OPEN_SETTINGS)) {
+                val i = Intent(baseContext, SetPreferencesActivity::class.java)
+                i.putExtra("controlConfig", true)
+                startActivity(i)
+            }
+        }
+
         //MediaPlayer mp = MediaPlayer.create(this, R.raw.bwv_115);
         //mp.start();
     }
@@ -242,17 +258,20 @@ class MainMenuActivity : Activity() {
 
                 // show what's new message
                 prefsManager.setLastVersion(AndouKun.VERSION)
-                showDialog(WHATS_NEW_DIALOG)
+                WhatsNewDialogFragment.newInstance()
+                    .show(supportFragmentManager, WhatsNewDialogFragment.TAG)
 
                 // screen controls were added in version 14
                 if (lastVersion in 1..<14 && prefsManager.getTiltControls()) {
                     if (touch.supportsMultitouch(this)) {
                         // show message about switching from tilt to screen controls
-                        showDialog(TILT_TO_SCREEN_CONTROLS_DIALOG)
+                        TiltControlsDialogFragment.newInstance()
+                            .show(supportFragmentManager, TiltControlsDialogFragment.TAG)
                     }
                 } else if (lastVersion == 0) {
                     // show message about auto-selected control schemes.
-                    showDialog(CONTROL_SETUP_DIALOG)
+                    ControlSetupDialogFragment.newInstance(selectedControlsString ?: "")
+                        .show(supportFragmentManager, ControlSetupDialogFragment.TAG)
                 }
             }
         }
@@ -285,44 +304,6 @@ class MainMenuActivity : Activity() {
         }
     }
 
-    @Deprecated("Deprecated in Java")
-    @SuppressLint("ApplySharedPref", "UseKtx")
-    override fun onCreateDialog(id: Int): Dialog {
-        val dialog: Dialog = if (id == WHATS_NEW_DIALOG) {
-            AlertDialog.Builder(this)
-                    .setTitle(R.string.whats_new_dialog_title)
-                    .setPositiveButton(R.string.whats_new_dialog_ok, null)
-                    .setMessage(R.string.whats_new_dialog_message)
-                    .create()
-        } else if (id == TILT_TO_SCREEN_CONTROLS_DIALOG) {
-            AlertDialog.Builder(this)
-                    .setTitle(R.string.onscreen_tilt_dialog_title)
-                    .setPositiveButton(R.string.onscreen_tilt_dialog_ok) { _, _ ->
-                        PreferencesManager.getInstance(this).setScreenControls(true)
-                    }
-                    .setNegativeButton(R.string.onscreen_tilt_dialog_cancel, null)
-                    .setMessage(R.string.onscreen_tilt_dialog_message)
-                    .create()
-        } else if (id == CONTROL_SETUP_DIALOG) {
-            val messageFormat = resources.getString(R.string.control_setup_dialog_message)
-            val message = String.format(messageFormat, selectedControlsString)
-            val sytledMessage: CharSequence = Html.fromHtml(message) // lame.
-            AlertDialog.Builder(this)
-                    .setTitle(R.string.control_setup_dialog_title)
-                    .setPositiveButton(R.string.control_setup_dialog_ok, null)
-                    .setNegativeButton(R.string.control_setup_dialog_change) { thisDialog, whichButton ->
-                        val i = Intent(baseContext, SetPreferencesActivity::class.java)
-                        i.putExtra("controlConfig", true)
-                        startActivity(i)
-                    }
-                    .setMessage(sytledMessage)
-                    .create()
-        } else {
-            super.onCreateDialog(id)
-        }
-        return dialog
-    }
-
     private inner class StartActivityAfterAnimation(private val intent: Intent) :
         Animation.AnimationListener {
         override fun onAnimationEnd(animation: Animation) {
@@ -345,11 +326,5 @@ class MainMenuActivity : Activity() {
         override fun onAnimationStart(animation: Animation) {
             // TODO Auto-generated method stub
         }
-    }
-
-    companion object {
-        private const val WHATS_NEW_DIALOG = 0
-        private const val TILT_TO_SCREEN_CONTROLS_DIALOG = 1
-        private const val CONTROL_SETUP_DIALOG = 2
     }
 }

--- a/app/src/main/java/com/replica/replicaisland/ui/NewGameDialogFragment.kt
+++ b/app/src/main/java/com/replica/replicaisland/ui/NewGameDialogFragment.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Jim Andreas
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.replica.replicaisland.ui
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.replica.replicaisland.R
+
+/**
+ * DialogFragment that confirms starting a new game when there's an existing save.
+ * Uses Fragment Result API to communicate the user's choice and game start type
+ * back to the activity.
+ */
+class NewGameDialogFragment : DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val gameStartType = requireArguments().getInt(ARG_GAME_START_TYPE)
+
+        return AlertDialog.Builder(requireContext())
+            .setTitle(R.string.new_game_dialog_title)
+            .setMessage(R.string.new_game_dialog_message)
+            .setPositiveButton(R.string.new_game_dialog_ok) { _, _ ->
+                setFragmentResult(REQUEST_KEY, bundleOf(
+                    RESULT_CONFIRMED to true,
+                    RESULT_GAME_START_TYPE to gameStartType
+                ))
+            }
+            .setNegativeButton(R.string.new_game_dialog_cancel, null)
+            .create()
+    }
+
+    companion object {
+        const val TAG = "NewGameDialogFragment"
+        const val REQUEST_KEY = "new_game_request"
+        const val RESULT_CONFIRMED = "confirmed"
+        const val RESULT_GAME_START_TYPE = "game_start_type"
+        private const val ARG_GAME_START_TYPE = "game_start_type"
+
+        fun newInstance(pendingGameStart: Int) = NewGameDialogFragment().apply {
+            arguments = bundleOf(ARG_GAME_START_TYPE to pendingGameStart)
+        }
+    }
+}

--- a/app/src/main/java/com/replica/replicaisland/ui/TiltControlsDialogFragment.kt
+++ b/app/src/main/java/com/replica/replicaisland/ui/TiltControlsDialogFragment.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Jim Andreas
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.replica.replicaisland.ui
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.replica.replicaisland.R
+
+/**
+ * DialogFragment that prompts users upgrading from tilt controls to switch to screen controls.
+ * Uses Fragment Result API to communicate the user's choice back to the activity.
+ */
+class TiltControlsDialogFragment : DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return AlertDialog.Builder(requireContext())
+            .setTitle(R.string.onscreen_tilt_dialog_title)
+            .setMessage(R.string.onscreen_tilt_dialog_message)
+            .setPositiveButton(R.string.onscreen_tilt_dialog_ok) { _, _ ->
+                setFragmentResult(REQUEST_KEY, bundleOf(RESULT_ENABLE_SCREEN_CONTROLS to true))
+            }
+            .setNegativeButton(R.string.onscreen_tilt_dialog_cancel, null)
+            .create()
+    }
+
+    companion object {
+        const val TAG = "TiltControlsDialogFragment"
+        const val REQUEST_KEY = "tilt_controls_request"
+        const val RESULT_ENABLE_SCREEN_CONTROLS = "enable_screen_controls"
+
+        fun newInstance() = TiltControlsDialogFragment()
+    }
+}

--- a/app/src/main/java/com/replica/replicaisland/ui/WhatsNewDialogFragment.kt
+++ b/app/src/main/java/com/replica/replicaisland/ui/WhatsNewDialogFragment.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Jim Andreas
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.replica.replicaisland.ui
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import com.replica.replicaisland.R
+
+/**
+ * DialogFragment that displays the "What's New" information when the app is updated.
+ */
+class WhatsNewDialogFragment : DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return AlertDialog.Builder(requireContext())
+            .setTitle(R.string.whats_new_dialog_title)
+            .setMessage(R.string.whats_new_dialog_message)
+            .setPositiveButton(R.string.whats_new_dialog_ok, null)
+            .create()
+    }
+
+    companion object {
+        const val TAG = "WhatsNewDialogFragment"
+
+        fun newInstance() = WhatsNewDialogFragment()
+    }
+}


### PR DESCRIPTION
## Summary

- Convert `MainMenuActivity` and `ExtrasMenuActivity` from `Activity` to `AppCompatActivity`
- Create 5 new DialogFragments to replace deprecated `showDialog()`/`onCreateDialog()` pattern:
  - `WhatsNewDialogFragment` - App update info dialog
  - `TiltControlsDialogFragment` - Tilt to screen controls migration prompt
  - `ControlSetupDialogFragment` - Auto-selected control scheme display
  - `NewGameDialogFragment` - New game confirmation when save exists
  - `ExtrasLockedDialogFragment` - Extras locked notification
- Use Fragment Result API for dialog callbacks
- Add instrumented tests for all 5 DialogFragments

## Test plan

- [ ] Build succeeds with `./gradlew assembleDebug`
- [ ] Run instrumented tests with `./gradlew connectedAndroidTest`
- [ ] Manual test: Clear app data and launch to trigger "What's New" dialog
- [ ] Manual test: Access locked extras to see locked dialog
- [ ] Manual test: Start new game with existing save to see confirmation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)